### PR TITLE
Fix mid score emoji

### DIFF
--- a/apps/web/supabase/functions/product_checker/lib/score.ts
+++ b/apps/web/supabase/functions/product_checker/lib/score.ts
@@ -3,6 +3,6 @@ export function combineScore(science:number, personal:number):number{
 }
 export function emojiFor(s:number){
   if(s>=80) return "😊";
-  if(s>=60) return "��";
+  if(s>=60) return "🙂";
   return "😟";
-} 
+}


### PR DESCRIPTION
## Summary
- return a valid emoji for scores between 60 and 79 in product_checker

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68408484442c832b903a8d2d9cfed8ec